### PR TITLE
Stopped url segment from being passed to route in before filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-_Disclaimer: This fork has been updated to work with Backbone 0.5.3_
+This fork has been updated to work with Backbone 0.9.10
 
 # Usage
 

--- a/backbone_filters.js
+++ b/backbone_filters.js
@@ -28,6 +28,7 @@
       Backbone.history.route(route, _.bind(function(fragment) {
         var args = this._extractParameters(route, fragment);    
         if (this._runFilters(this.before, fragment, args)) {
+          args.shift();
           callback && callback.apply(this, args);
           this._runFilters(this.after, fragment, args);
           this.trigger.apply(this, ['route:' + name].concat(args));

--- a/backbone_filters.js
+++ b/backbone_filters.js
@@ -1,37 +1,40 @@
+//From: https://github.com/danharper/backbone_filters
+//Updated by James Seppi to work with Backbone 0.9.10
 (function() {
-	_.extend(Backbone.Router.prototype, Backbone.Events, {
-		before: {},
-		after: {},
-		_runFilters: function(filters, fragment, args) {
-			if (_(filters).isEmpty()) {
-				return true;
-			}
-			var failingFilter = _(filters).detect(function(func, filterRoute) {
-				if (!_.isRegExp(filterRoute)) {
-					// filterRoute = this._routeToRegExp(filterRoute);
-					filterRoute = new RegExp(filterRoute);
-				}
-				if (filterRoute.test(fragment)) {
-					var result = (_.isFunction(func) ? func.apply(this, args) : this[func].apply(this, args));
-					return _.isBoolean(result) && result === false;
-				}
-				return false;
-			},
-			this);
-						
-			return failingFilter ? false : true;
-		},
-		route: function(route, name, callback) {
-			Backbone.history || (Backbone.history = new Backbone.History);
-			if (!_.isRegExp(route)) route = this._routeToRegExp(route);
-			Backbone.history.route(route, _.bind(function(fragment) {
-				var args = this._extractParameters(route, fragment);
-				if (this._runFilters(this.before, fragment, args)) {
-					callback.apply(this, args);
-					this._runFilters(this.after, fragment, args);
-					this.trigger.apply(this, ['route:' + name].concat(args));
-				}
-			}, this));
-		}
-	});
+    _.extend(Backbone.Router.prototype, Backbone.Events, {
+        before: {},
+        after: {},
+        _runFilters: function(filters, fragment, args) {
+            if (_(filters).isEmpty()) {
+                return true;
+            }
+            var failingFilter = _(filters).detect(function(func, filterRoute) {
+                if (!_.isRegExp(filterRoute)) {
+                    // filterRoute = this._routeToRegExp(filterRoute);
+                    filterRoute = new RegExp(filterRoute);
+                }
+                if (filterRoute.test(fragment)) {
+                    var result = (_.isFunction(func) ? func.apply(this, args) : this[func].apply(this, args));
+                    return _.isBoolean(result) && result === false;
+                }
+                return false;
+            },
+            this);
+
+            return failingFilter ? false : true;
+        },
+        route: function(route, name, callback) {
+            if (!_.isRegExp(route)) route = this._routeToRegExp(route);
+            if (!callback) callback = this[name];
+            Backbone.history.route(route, _.bind(function(fragment) {
+                var args = this._extractParameters(route, fragment);    
+                if (this._runFilters(this.before, fragment, args)) {
+                    callback && callback.apply(this, args);
+                    this._runFilters(this.after, fragment, args);
+                    this.trigger.apply(this, ['route:' + name].concat(args));
+                    Backbone.history.trigger('route', this, name, args);
+                }
+            }, this));
+        }
+    });
 }).call(this);


### PR DESCRIPTION
Where I was using:

``` javascript
routes: {
  "foo/:bar" : "foo"
},

foo: function(bar){
  // do stuff with bar
},

before: {
  '^foo': function(route,param){
    // some filter logic
      // route = 'foo'
      // param = route's first function param
    return true;
  }
}
```

On the route, foo was now the second parameter, with the first parameter being the url segment, breaking the initial route code (requiring refactoring):

``` javascript
foo: function(segment,bar){
  // do stuff with bar
}
```

I figured this might be unwanted behaviour?
