### PR TITLE
Updated to 0.9.10 and a bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,38 @@ _Disclaimer: This fork has been updated to work with Backbone 0.9.10_
 
 Include `backbone_filters.js` after Backbone.
 
-In your router you can now add:
+In your router where routes are defined as:
 
 ```javascript
-before: {
-	'^clerks' : function(route) {
-		/* do stuff to all routes starting with 'clerks' */
-		/* return false to halt execution */
-	},
-	'another reg ex' : function(route) { }
+routes : {
+    "clerks/:arg1/:arg2" : "clerks"
+}
+
+clerks : function(arg1, arg2) {
+    // router logic, with arg1 and arg2
+},
+```
+
+You can now add:
+
+```javascript
+before : {
+  '^clerks' : function(route, arg1, arg2) {
+    /* do stuff to all routes starting with 'clerks' */
+    /* return false to halt execution */
+  },
+  'another reg ex' : function(route) { }
 },
 
-after: {
-	'^clerks' : function(route) {
-		/* do stuff */
-	},
-	'another reg ex' : function(route) { }	
+after : {
+  '^clerks' : function(route, arg1, arg2) {
+    /* do stuff */
+  },
+  'another reg ex' : function(route) { }
 }
 ```
 
 Your filters will be called and if a filter returns false, the filter chain is halted.
-If a before filter chain is halted, the action in the Router will not be called. Your
-filters will receive the same arguments that get passed to the actions.
+If a before filter chain is halted, the action in the Router will not be called.
+
+Your filters will receive the same arguments that get passed to the actions (following the first argument, route). The route argument contains the entire matched filter segment (including args).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-_Disclaimer: This fork has been updated to work with Backbone 0.5.3_
+_Disclaimer: This fork has been updated to work with Backbone 0.9.10_
 
 # Usage
 

--- a/backbone_filters.js
+++ b/backbone_filters.js
@@ -29,6 +29,7 @@
 			Backbone.history.route(route, _.bind(function(fragment) {
 				var args = this._extractParameters(route, fragment);
 				if (this._runFilters(this.before, fragment, args)) {
+          args.shift();
 					callback && callback.apply(this, args);
 					this._runFilters(this.after, fragment, args);
 					this.trigger.apply(this, ['route:' + name].concat(args));

--- a/backbone_filters.js
+++ b/backbone_filters.js
@@ -25,12 +25,14 @@
 		route: function(route, name, callback) {
 			Backbone.history || (Backbone.history = new Backbone.History);
 			if (!_.isRegExp(route)) route = this._routeToRegExp(route);
+			if (!callback) callback = this[name];
 			Backbone.history.route(route, _.bind(function(fragment) {
 				var args = this._extractParameters(route, fragment);
 				if (this._runFilters(this.before, fragment, args)) {
-					callback.apply(this, args);
+					callback && callback.apply(this, args);
 					this._runFilters(this.after, fragment, args);
 					this.trigger.apply(this, ['route:' + name].concat(args));
+					Backbone.history.trigger('route', this, name, args);
 				}
 			}, this));
 		}


### PR DESCRIPTION
Updated to 0.9.10 using https://github.com/jseppi/backbone_filters/commit/2b2e6411678ab2ac8a88d4c3bb48a01e48cae947

Prevented url segment from being passed back to route, seemed like erroneous behaviour.

_(I closed the previous pull request, I had changed the indentation and the diff had almost the entire file being changed)_
